### PR TITLE
Video plugin: player-agnostic core + expo-video adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Typecheck core
+      # Build first: the video package resolves core types via its built dist.
+      - name: Build packages
+        run: npm run build
+
+      - name: Typecheck packages
         run: npm run typecheck
 
       - name: Run tests
         run: npm test
-
-      - name: Build core
-        run: npm run build
 
       - name: Typecheck example
         working-directory: example

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ tagsStyles={{
 
 **Documents:** full-document HTML works too — literal `<html>`/`<body>` render as plain block containers, and `<head>`, `<title>`, `<style>`, `<script>`, `<link>`, `<meta>`, `<base>` are ignored by default.
 
-**Media:** `<video>` / `<audio>` render their spec fallback content as blocks and expose all attributes (`attribs`) to custom renderers; native playback ships as plugin packages (see below).
+**Media:** `<video>` / `<audio>` render their spec fallback content as blocks and expose all attributes (`attribs`) to custom renderers; for native playback add [`@nikpnevmatikos/html-renderer-video`](https://github.com/NikPnevmatikos/Html-Renderer/tree/main/packages/video) (see Plugin packages below).
 
 ## Supported CSS
 
@@ -269,17 +269,18 @@ Actively on the roadmap:
 - **Advanced CSS** — transforms, flex/grid layout of HTML content.
 - **Intrinsic table column widths** — columns render equal-width (`flex: 1`); `width` on `<col>` / cells is ignored.
 
-## Plugin packages (planned)
+## Plugin packages
 
-Features that need native dependencies ship as separate packages so the core stays zero-native-modules. Each uses the core's `customRenderers` and `customHTMLElementModels` APIs — no core changes needed to add them.
+Features that need native dependencies ship as separate packages so the core stays zero-native-modules. Each uses the core's `customRenderers` and `customHTMLElementModels` APIs.
 
-| Tags | Planned package | Native peer dep |
-|---|---|---|
-| `<iframe>` | `@nikpnevmatikos/html-renderer-webview` | `react-native-webview` |
-| `<video>`, `<audio>` | `@nikpnevmatikos/html-renderer-video` | `expo-video` or `react-native-video` |
-| `<svg>` | `@nikpnevmatikos/html-renderer-svg` | `react-native-svg` |
+| Tags | Package | Native peer dep | Status |
+|---|---|---|---|
+| `<video>` | [`@nikpnevmatikos/html-renderer-video`](https://github.com/NikPnevmatikos/Html-Renderer/tree/main/packages/video) | `expo-video` (optional — bring-your-own-player supported) | **Available** |
+| `<audio>` | `@nikpnevmatikos/html-renderer-video` | — | Planned |
+| `<iframe>` | `@nikpnevmatikos/html-renderer-webview` | `react-native-webview` | Planned |
+| `<svg>` | `@nikpnevmatikos/html-renderer-svg` | `react-native-svg` | Planned |
 
-Until these ship, you can wire any of these tags yourself via `customRenderers` — the same API the plugins will use. See the "Custom renderer" and "Custom HTML element models" examples above.
+For tags without a plugin yet, wire them yourself via `customRenderers` — the same API the plugins use. See the "Custom renderer" and "Custom HTML element models" examples above.
 
 ## Development
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -9,6 +9,9 @@ import {
   type TransformDom,
   type DomNode,
 } from '@nikpnevmatikos/html-renderer';
+import { createExpoVideoRenderers } from '@nikpnevmatikos/html-renderer-video/expo';
+
+const videoSupport = createExpoVideoRenderers();
 
 const demoHtml = `
   <h1>HtmlRenderer demo</h1>
@@ -75,6 +78,13 @@ function hello(name) {
 
   <h3>Image (auto-fit to contentWidth)</h3>
   <img src="https://picsum.photos/seed/big/1200/600" alt="Auto-fit big image" />
+
+  <h2>Video (@nikpnevmatikos/html-renderer-video)</h2>
+  <p>Rendered with the expo-video adapter — poster, native controls, sized by contentWidth:</p>
+  <video controls width="640" height="360" poster="https://picsum.photos/seed/videoposter/640/360">
+    <source src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4" type="video/mp4">
+    Your device cannot play this video.
+  </video>
 `;
 
 const stylesheet = `
@@ -119,6 +129,7 @@ const customHTMLElementModels: Record<string, HTMLElementModel> = {
       marginVertical: 6,
     },
   },
+  ...videoSupport.customHTMLElementModels,
 };
 
 const renderersProps = {
@@ -129,6 +140,7 @@ const customRenderers: Record<string, CustomRenderer> = {
   hr: () => (
     <View style={{ height: 2, backgroundColor: '#1a73e8', marginVertical: 16 }} />
   ),
+  ...videoSupport.customRenderers,
 };
 
 const onLinkPress: OnLinkPress = (href, attribs) => {

--- a/example/app.json
+++ b/example/app.json
@@ -25,6 +25,9 @@
     },
     "web": {
       "favicon": "./assets/favicon.png"
-    }
+    },
+    "plugins": [
+      "expo-video"
+    ]
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -13,6 +13,7 @@
     "@nikpnevmatikos/html-renderer": "*",
     "expo": "~54.0.33",
     "expo-status-bar": "~3.0.9",
+    "expo-video": "~3.0.16",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2750,6 +2750,10 @@
       "resolved": "packages/core",
       "link": true
     },
+    "node_modules/@nikpnevmatikos/html-renderer-video": {
+      "resolved": "packages/video",
+      "link": true
+    },
     "node_modules/@react-native/assets-registry": {
       "version": "0.81.5",
       "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.81.5.tgz",
@@ -9892,6 +9896,29 @@
         "node": ">=20"
       },
       "peerDependencies": {
+        "react": ">=18",
+        "react-native": ">=0.73"
+      }
+    },
+    "packages/video": {
+      "name": "@nikpnevmatikos/html-renderer-video",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@nikpnevmatikos/html-renderer": "*",
+        "@types/jest": "^29.5.14",
+        "@types/react": "~19.1.0",
+        "jest": "^29.7.0",
+        "react": "19.1.0",
+        "react-native": "0.81.5",
+        "ts-jest": "^29.4.9",
+        "typescript": "~5.9.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@nikpnevmatikos/html-renderer": ">=0.3.0",
         "react": ">=18",
         "react-native": ">=0.73"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@nikpnevmatikos/html-renderer": "*",
         "expo": "~54.0.33",
         "expo-status-bar": "~3.0.9",
+        "expo-video": "~3.0.16",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
@@ -4851,6 +4852,17 @@
         "react-native-is-edge-to-edge": "^1.2.1"
       },
       "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-video": {
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/expo-video/-/expo-video-3.0.16.tgz",
+      "integrity": "sha512-H1HlxcHGomZItqisGfW3YL/G9BHtNBfVSimDJcLuyxyU87wFnV8loO9tCjuhufkfh/aTa2sW5BYAjLjg9DvnBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
         "react": "*",
         "react-native": "*"
       }
@@ -9908,6 +9920,7 @@
         "@nikpnevmatikos/html-renderer": "*",
         "@types/jest": "^29.5.14",
         "@types/react": "~19.1.0",
+        "expo-video": "~3.0.16",
         "jest": "^29.7.0",
         "react": "19.1.0",
         "react-native": "0.81.5",
@@ -9919,8 +9932,14 @@
       },
       "peerDependencies": {
         "@nikpnevmatikos/html-renderer": ">=0.3.0",
+        "expo-video": ">=2.0.0",
         "react": ">=18",
         "react-native": ">=0.73"
+      },
+      "peerDependenciesMeta": {
+        "expo-video": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "example"
   ],
   "scripts": {
-    "build": "npm run build -w @nikpnevmatikos/html-renderer",
+    "build": "npm run build -w @nikpnevmatikos/html-renderer && npm run build -w @nikpnevmatikos/html-renderer-video",
     "dev": "npm run dev -w @nikpnevmatikos/html-renderer",
-    "typecheck": "npm run typecheck -w @nikpnevmatikos/html-renderer",
-    "test": "npm run test -w @nikpnevmatikos/html-renderer"
+    "typecheck": "npm run typecheck --workspaces --if-present",
+    "test": "npm run test --workspaces --if-present"
   }
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -76,7 +76,7 @@ tagsStyles={{
 
 **Documents:** full-document HTML works too — literal `<html>`/`<body>` render as plain block containers, and `<head>`, `<title>`, `<style>`, `<script>`, `<link>`, `<meta>`, `<base>` are ignored by default.
 
-**Media:** `<video>` / `<audio>` render their spec fallback content as blocks and expose all attributes (`attribs`) to custom renderers; native playback ships as plugin packages (see below).
+**Media:** `<video>` / `<audio>` render their spec fallback content as blocks and expose all attributes (`attribs`) to custom renderers; for native playback add [`@nikpnevmatikos/html-renderer-video`](https://github.com/NikPnevmatikos/Html-Renderer/tree/main/packages/video) (see Plugin packages below).
 
 ## Supported CSS
 
@@ -269,17 +269,18 @@ Actively on the roadmap:
 - **Advanced CSS** — transforms, flex/grid layout of HTML content.
 - **Intrinsic table column widths** — columns render equal-width (`flex: 1`); `width` on `<col>` / cells is ignored.
 
-## Plugin packages (planned)
+## Plugin packages
 
-Features that need native dependencies ship as separate packages so the core stays zero-native-modules. Each uses the core's `customRenderers` and `customHTMLElementModels` APIs — no core changes needed to add them.
+Features that need native dependencies ship as separate packages so the core stays zero-native-modules. Each uses the core's `customRenderers` and `customHTMLElementModels` APIs.
 
-| Tags | Planned package | Native peer dep |
-|---|---|---|
-| `<iframe>` | `@nikpnevmatikos/html-renderer-webview` | `react-native-webview` |
-| `<video>`, `<audio>` | `@nikpnevmatikos/html-renderer-video` | `expo-video` or `react-native-video` |
-| `<svg>` | `@nikpnevmatikos/html-renderer-svg` | `react-native-svg` |
+| Tags | Package | Native peer dep | Status |
+|---|---|---|---|
+| `<video>` | [`@nikpnevmatikos/html-renderer-video`](https://github.com/NikPnevmatikos/Html-Renderer/tree/main/packages/video) | `expo-video` (optional — bring-your-own-player supported) | **Available** |
+| `<audio>` | `@nikpnevmatikos/html-renderer-video` | — | Planned |
+| `<iframe>` | `@nikpnevmatikos/html-renderer-webview` | `react-native-webview` | Planned |
+| `<svg>` | `@nikpnevmatikos/html-renderer-svg` | `react-native-svg` | Planned |
 
-Until these ship, you can wire any of these tags yourself via `customRenderers` — the same API the plugins will use. See the "Custom renderer" and "Custom HTML element models" examples above.
+For tags without a plugin yet, wire them yourself via `customRenderers` — the same API the plugins use. See the "Custom renderer" and "Custom HTML element models" examples above.
 
 ## Development
 

--- a/packages/video/CHANGELOG.md
+++ b/packages/video/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to `@nikpnevmatikos/html-renderer-video` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-07-15
+
+Initial release.
+
+### Added
+
+- Player-agnostic core: `createVideoRenderers(Player)` returns the `customRenderers` / `customHTMLElementModels` pair that wires `<video>` to any player component implementing the `VideoPlayerProps` contract.
+- HTML semantics: the `src` attribute wins, else the first usable `<source>` child (its `type` carried as `source.mimeType`); elements with no playable source render their HTML fallback content; width is capped at `contentWidth`; aspect ratio derives from the `width`/`height` attributes (16/9 default); boolean attributes `controls`, `autoplay`, `muted`, `loop`.
+- `expo-video` adapter at `@nikpnevmatikos/html-renderer-video/expo`: `createExpoVideoRenderers()` and `ExpoVideoPlayer`. Poster renders as an overlay until playback first starts, with a tap-to-play badge (also shown for controls-less videos, which would otherwise be unstartable). A loading spinner shows when playback is requested before the media is ready and during mid-playback buffering stalls. Autoplay is re-requested after mount (the web player drops `play()` issued from the `useVideoPlayer` setup callback). `expo-video` is an optional peer dependency, only required when importing the `./expo` subpath.

--- a/packages/video/LICENSE
+++ b/packages/video/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Html-Renderer contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/video/README.md
+++ b/packages/video/README.md
@@ -1,11 +1,80 @@
 # @nikpnevmatikos/html-renderer-video
 
-`<video>` support for [`@nikpnevmatikos/html-renderer`](https://www.npmjs.com/package/@nikpnevmatikos/html-renderer) — a player-agnostic core with a pre-wired `expo-video` adapter.
+`<video>` support for [`@nikpnevmatikos/html-renderer`](https://www.npmjs.com/package/@nikpnevmatikos/html-renderer) — a player-agnostic core with a ready-made `expo-video` adapter.
 
-> **Status:** in development — player-agnostic core and `expo-video` adapter implemented; docs and example pending. Not yet published.
+> **Status:** in development — not yet published.
 
-## Design
+## Install
 
-- `createVideoRenderers(Player)` returns `{ customRenderers, customHTMLElementModels }` to spread into `HtmlRenderer` props. Bring any player component.
-- `@nikpnevmatikos/html-renderer-video/expo` (planned) ships a ready-made adapter using `expo-video` (optional peer dependency). A `react-native-video` adapter can follow as another subpath without a new package.
-- Source resolution follows HTML semantics: the `src` attribute, else the first usable `<source>` child; elements with no source render their fallback content.
+```bash
+npm install @nikpnevmatikos/html-renderer-video
+npx expo install expo-video   # only if you use the expo adapter
+```
+
+Requires `@nikpnevmatikos/html-renderer >= 0.3.0`. `expo-video` is an **optional** peer dependency — it is only loaded when you import from `./expo`.
+
+## Quick start (expo)
+
+```tsx
+import { HtmlRenderer } from '@nikpnevmatikos/html-renderer';
+import { createExpoVideoRenderers } from '@nikpnevmatikos/html-renderer-video/expo';
+
+const videoSupport = createExpoVideoRenderers();
+
+<HtmlRenderer
+  html='<video controls poster="p.jpg" src="https://example.com/movie.mp4"></video>'
+  contentWidth={width}
+  {...videoSupport}
+/>;
+```
+
+Already passing your own `customRenderers` / `customHTMLElementModels`? Merge instead of spreading:
+
+```tsx
+<HtmlRenderer
+  customRenderers={{ ...myRenderers, ...videoSupport.customRenderers }}
+  customHTMLElementModels={{ ...myModels, ...videoSupport.customHTMLElementModels }}
+/>
+```
+
+## Bring your own player
+
+The core is player-agnostic — `createVideoRenderers(Player)` accepts any component taking `VideoPlayerProps`:
+
+```tsx
+import { createVideoRenderers, type VideoPlayerProps } from '@nikpnevmatikos/html-renderer-video';
+
+function MyPlayer({ source, poster, controls, width, aspectRatio }: VideoPlayerProps) {
+  return <SomeVideoLib uri={source.uri} /* ... */ />;
+}
+
+const videoSupport = createVideoRenderers(MyPlayer);
+```
+
+`Player` is rendered as a real component, so hooks are legal inside it.
+
+| `VideoPlayerProps` | Meaning |
+|---|---|
+| `source` | `{ uri, mimeType? }` — resolved playable source |
+| `poster` | Poster image URL, when present |
+| `controls` / `autoplay` / `muted` / `loop` | The HTML boolean attributes |
+| `width` | Pixel width: `min(width attribute, contentWidth)` when known |
+| `aspectRatio` | From the `width`/`height` attributes, else `16/9` |
+| `node` | The raw render-tree element, for advanced adapters |
+
+## HTML semantics
+
+- **Source resolution:** the element's `src` attribute wins; otherwise the first `<source>` child with a `src` (its `type` becomes `source.mimeType`).
+- **Fallback content:** a `<video>` with no usable source renders its children — exactly what fallback content is for in HTML.
+- **Sizing:** width is capped at `contentWidth`; height follows the aspect ratio.
+- **Poster (expo adapter):** `expo-video` has no native poster, so the adapter overlays the poster image until playback first starts. The overlay ignores touches, so native controls stay usable.
+
+## Not (yet) covered
+
+- `<audio>` — planned; needs custom control UI.
+- A `react-native-video` adapter — planned as a `./rnv` subpath if there is demand; `createVideoRenderers` already supports any player today.
+- YouTube/Vimeo `<iframe>` embeds are a different tag — that belongs to the planned webview plugin, not this package.
+
+## License
+
+MIT — see [LICENSE](./LICENSE).

--- a/packages/video/README.md
+++ b/packages/video/README.md
@@ -1,0 +1,11 @@
+# @nikpnevmatikos/html-renderer-video
+
+`<video>` support for [`@nikpnevmatikos/html-renderer`](https://www.npmjs.com/package/@nikpnevmatikos/html-renderer) — a player-agnostic core with a pre-wired `expo-video` adapter.
+
+> **Status:** in development — not yet published.
+
+## Design
+
+- `createVideoRenderers(Player)` returns `{ customRenderers, customHTMLElementModels }` to spread into `HtmlRenderer` props. Bring any player component.
+- `@nikpnevmatikos/html-renderer-video/expo` (planned) ships a ready-made adapter using `expo-video` (optional peer dependency). A `react-native-video` adapter can follow as another subpath without a new package.
+- Source resolution follows HTML semantics: the `src` attribute, else the first usable `<source>` child; elements with no source render their fallback content.

--- a/packages/video/README.md
+++ b/packages/video/README.md
@@ -2,7 +2,7 @@
 
 `<video>` support for [`@nikpnevmatikos/html-renderer`](https://www.npmjs.com/package/@nikpnevmatikos/html-renderer) — a player-agnostic core with a pre-wired `expo-video` adapter.
 
-> **Status:** in development — player-agnostic core implemented; `expo-video` adapter pending. Not yet published.
+> **Status:** in development — player-agnostic core and `expo-video` adapter implemented; docs and example pending. Not yet published.
 
 ## Design
 

--- a/packages/video/README.md
+++ b/packages/video/README.md
@@ -2,8 +2,6 @@
 
 `<video>` support for [`@nikpnevmatikos/html-renderer`](https://www.npmjs.com/package/@nikpnevmatikos/html-renderer) — a player-agnostic core with a ready-made `expo-video` adapter.
 
-> **Status:** in development — not yet published.
-
 ## Install
 
 ```bash
@@ -67,7 +65,8 @@ const videoSupport = createVideoRenderers(MyPlayer);
 - **Source resolution:** the element's `src` attribute wins; otherwise the first `<source>` child with a `src` (its `type` becomes `source.mimeType`).
 - **Fallback content:** a `<video>` with no usable source renders its children — exactly what fallback content is for in HTML.
 - **Sizing:** width is capped at `contentWidth`; height follows the aspect ratio.
-- **Poster (expo adapter):** `expo-video` has no native poster, so the adapter overlays the poster image until playback first starts. The overlay ignores touches, so native controls stay usable.
+- **Poster & play badge (expo adapter):** `expo-video` has no native poster, so the adapter overlays the poster image until playback first starts, together with a play badge — tapping it starts playback. The badge also appears on videos without `controls`, which would otherwise be unstartable (HTML gives them no UI).
+- **Loading (expo adapter):** a spinner replaces the play badge when playback is requested before the media is ready, and a spinner overlay appears during mid-playback buffering stalls.
 
 ## Not (yet) covered
 

--- a/packages/video/README.md
+++ b/packages/video/README.md
@@ -2,7 +2,7 @@
 
 `<video>` support for [`@nikpnevmatikos/html-renderer`](https://www.npmjs.com/package/@nikpnevmatikos/html-renderer) — a player-agnostic core with a pre-wired `expo-video` adapter.
 
-> **Status:** in development — not yet published.
+> **Status:** in development — player-agnostic core implemented; `expo-video` adapter pending. Not yet published.
 
 ## Design
 

--- a/packages/video/expo.d.ts
+++ b/packages/video/expo.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/expo';

--- a/packages/video/expo.js
+++ b/packages/video/expo.js
@@ -1,0 +1,2 @@
+// Physical stub for resolvers that ignore the package.json "exports" map.
+export * from './dist/expo';

--- a/packages/video/package.json
+++ b/packages/video/package.json
@@ -23,10 +23,16 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./expo": {
+      "types": "./dist/expo.d.ts",
+      "default": "./dist/expo.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [
     "dist",
+    "expo.js",
+    "expo.d.ts",
     "README.md",
     "LICENSE"
   ],
@@ -61,11 +67,18 @@
   ],
   "peerDependencies": {
     "@nikpnevmatikos/html-renderer": ">=0.3.0",
+    "expo-video": ">=2.0.0",
     "react": ">=18",
     "react-native": ">=0.73"
   },
+  "peerDependenciesMeta": {
+    "expo-video": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@nikpnevmatikos/html-renderer": "*",
+    "expo-video": "~3.0.16",
     "@types/jest": "^29.5.14",
     "@types/react": "~19.1.0",
     "jest": "^29.7.0",

--- a/packages/video/package.json
+++ b/packages/video/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "@nikpnevmatikos/html-renderer-video",
+  "version": "0.1.0",
+  "private": true,
+  "description": "<video> support for @nikpnevmatikos/html-renderer — player-agnostic core with an expo-video adapter.",
+  "author": "NikPnevmatikos",
+  "license": "MIT",
+  "homepage": "https://github.com/NikPnevmatikos/Html-Renderer#readme",
+  "bugs": {
+    "url": "https://github.com/NikPnevmatikos/Html-Renderer/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NikPnevmatikos/Html-Renderer.git",
+    "directory": "packages/video"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "react-native": "./dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch --preserveWatchOutput",
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "clean": "rimraf dist"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "testMatch": [
+      "<rootDir>/src/**/*.test.ts"
+    ]
+  },
+  "keywords": [
+    "react-native",
+    "html",
+    "renderer",
+    "video",
+    "expo-video",
+    "expo"
+  ],
+  "peerDependencies": {
+    "@nikpnevmatikos/html-renderer": ">=0.3.0",
+    "react": ">=18",
+    "react-native": ">=0.73"
+  },
+  "devDependencies": {
+    "@nikpnevmatikos/html-renderer": "*",
+    "@types/jest": "^29.5.14",
+    "@types/react": "~19.1.0",
+    "jest": "^29.7.0",
+    "react": "19.1.0",
+    "react-native": "0.81.5",
+    "ts-jest": "^29.4.9",
+    "typescript": "~5.9.2"
+  }
+}

--- a/packages/video/package.json
+++ b/packages/video/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@nikpnevmatikos/html-renderer-video",
   "version": "0.1.0",
-  "private": true,
   "description": "<video> support for @nikpnevmatikos/html-renderer — player-agnostic core with an expo-video adapter.",
   "author": "NikPnevmatikos",
   "license": "MIT",
@@ -34,6 +33,7 @@
     "expo.js",
     "expo.d.ts",
     "README.md",
+    "CHANGELOG.md",
     "LICENSE"
   ],
   "publishConfig": {

--- a/packages/video/src/expo.tsx
+++ b/packages/video/src/expo.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState, type ReactElement } from 'react';
+import { Image, StyleSheet, View } from 'react-native';
+import { VideoView, useVideoPlayer } from 'expo-video';
+import { useEventListener } from 'expo';
+import type { VideoPlayerProps, VideoRenderersConfig } from './types';
+import { createVideoRenderers } from './index';
+
+/**
+ * expo-video adapter for the HTML <video> renderer.
+ *
+ * Attribute mapping: controls → nativeControls, muted/loop → player
+ * properties, autoplay → player.play() on creation, poster → an Image
+ * overlay shown until playback first starts (expo-video has no native
+ * poster support; the overlay ignores touches so the controls stay usable).
+ */
+export function ExpoVideoPlayer({
+  source,
+  poster,
+  controls,
+  autoplay,
+  muted,
+  loop,
+  width,
+  aspectRatio,
+}: VideoPlayerProps): ReactElement {
+  const player = useVideoPlayer(source.uri, (p) => {
+    p.muted = muted;
+    p.loop = loop;
+    if (autoplay) p.play();
+  });
+
+  // On web the setup callback can run before the <video> element attaches,
+  // dropping the play() call — re-request after mount (a no-op when the
+  // player is already playing, e.g. on native).
+  useEffect(() => {
+    if (autoplay) player.play();
+  }, [player, autoplay]);
+
+  const [started, setStarted] = useState(autoplay);
+  useEventListener(player, 'playingChange', (payload) => {
+    if (payload.isPlaying) setStarted(true);
+  });
+
+  return (
+    <View style={[width !== undefined ? { width } : styles.fullWidth, { aspectRatio }]}>
+      <VideoView
+        player={player}
+        nativeControls={controls}
+        contentFit="contain"
+        style={StyleSheet.absoluteFill}
+      />
+      {poster !== undefined && !started ? (
+        <View style={StyleSheet.absoluteFill} pointerEvents="none">
+          <Image
+            source={{ uri: poster }}
+            resizeMode="cover"
+            style={StyleSheet.absoluteFill}
+          />
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+/** Ready-made HtmlRenderer props wired to expo-video: spread and go. */
+export function createExpoVideoRenderers(): VideoRenderersConfig {
+  return createVideoRenderers(ExpoVideoPlayer);
+}
+
+const styles = StyleSheet.create({
+  fullWidth: { width: '100%' },
+});

--- a/packages/video/src/expo.tsx
+++ b/packages/video/src/expo.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactElement } from 'react';
-import { Image, StyleSheet, View } from 'react-native';
+import { ActivityIndicator, Image, Pressable, StyleSheet, View } from 'react-native';
 import { VideoView, useVideoPlayer } from 'expo-video';
 import { useEventListener } from 'expo';
 import type { VideoPlayerProps, VideoRenderersConfig } from './types';
@@ -11,7 +11,13 @@ import { createVideoRenderers } from './index';
  * Attribute mapping: controls → nativeControls, muted/loop → player
  * properties, autoplay → player.play() on creation, poster → an Image
  * overlay shown until playback first starts (expo-video has no native
- * poster support; the overlay ignores touches so the controls stay usable).
+ * poster support).
+ *
+ * Until playback first starts, a play badge is overlaid whenever the poster
+ * would otherwise hide the controls, or the element has no controls at all —
+ * without it a poster frame is indistinguishable from a plain image, and a
+ * controls-less video would be unstartable. Tapping the overlay starts
+ * playback.
  */
 export function ExpoVideoPlayer({
   source,
@@ -41,6 +47,18 @@ export function ExpoVideoPlayer({
     if (payload.isPlaying) setStarted(true);
   });
 
+  const [status, setStatus] = useState(player.status);
+  useEventListener(player, 'statusChange', (payload) => {
+    setStatus(payload.status);
+  });
+
+  // Tracks a play request made before the media was ready, so the play
+  // badge can show a spinner instead of appearing to do nothing.
+  const [pendingPlay, setPendingPlay] = useState(false);
+
+  const showOverlay = !started && (poster !== undefined || !controls);
+  const buffering = status === 'loading';
+
   return (
     <View style={[width !== undefined ? { width } : styles.fullWidth, { aspectRatio }]}>
       <VideoView
@@ -49,13 +67,37 @@ export function ExpoVideoPlayer({
         contentFit="contain"
         style={StyleSheet.absoluteFill}
       />
-      {poster !== undefined && !started ? (
-        <View style={StyleSheet.absoluteFill} pointerEvents="none">
-          <Image
-            source={{ uri: poster }}
-            resizeMode="cover"
-            style={StyleSheet.absoluteFill}
-          />
+      {showOverlay ? (
+        <Pressable
+          style={styles.overlay}
+          onPress={() => {
+            setPendingPlay(true);
+            player.play();
+          }}
+          accessibilityRole="button"
+          accessibilityLabel="Play video"
+        >
+          {poster !== undefined ? (
+            <Image
+              source={{ uri: poster }}
+              resizeMode="cover"
+              style={StyleSheet.absoluteFill}
+            />
+          ) : null}
+          <View style={styles.playBadge}>
+            {pendingPlay && buffering ? (
+              <ActivityIndicator color="#ffffff" />
+            ) : (
+              <View style={styles.playTriangle} />
+            )}
+          </View>
+        </Pressable>
+      ) : null}
+      {started && buffering ? (
+        <View style={styles.overlay} pointerEvents="none">
+          <View style={styles.playBadge}>
+            <ActivityIndicator color="#ffffff" />
+          </View>
         </View>
       ) : null}
     </View>
@@ -69,4 +111,28 @@ export function createExpoVideoRenderers(): VideoRenderersConfig {
 
 const styles = StyleSheet.create({
   fullWidth: { width: '100%' },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  playBadge: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: 'rgba(0, 0, 0, 0.55)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  playTriangle: {
+    width: 0,
+    height: 0,
+    marginLeft: 6,
+    borderTopWidth: 12,
+    borderBottomWidth: 12,
+    borderLeftWidth: 20,
+    borderTopColor: 'transparent',
+    borderBottomColor: 'transparent',
+    borderLeftColor: '#ffffff',
+  },
 });

--- a/packages/video/src/extract.test.ts
+++ b/packages/video/src/extract.test.ts
@@ -1,0 +1,110 @@
+import { extractMediaSource, extractPlayerProps } from './extract';
+import { el, text } from './fixtures.test-util';
+
+describe('extractMediaSource', () => {
+  it('uses the src attribute directly', () => {
+    expect(extractMediaSource(el('video', { src: 'v.mp4' }))).toEqual({
+      uri: 'v.mp4',
+    });
+  });
+
+  it('falls back to the first <source> child with a src, keeping its type', () => {
+    const node = el('video', {}, [
+      el('source', { type: 'video/webm' }),
+      el('source', { src: 'v.webm', type: 'video/webm' }),
+      el('source', { src: 'v.mp4', type: 'video/mp4' }),
+    ]);
+    expect(extractMediaSource(node)).toEqual({
+      uri: 'v.webm',
+      mimeType: 'video/webm',
+    });
+  });
+
+  it('src attribute wins over <source> children', () => {
+    const node = el('video', { src: 'direct.mp4' }, [
+      el('source', { src: 'child.mp4' }),
+    ]);
+    expect(extractMediaSource(node)).toEqual({ uri: 'direct.mp4' });
+  });
+
+  it('omits mimeType when the winning <source> has no type', () => {
+    const node = el('video', {}, [el('source', { src: 'v.mp4' })]);
+    expect(extractMediaSource(node)).toEqual({ uri: 'v.mp4' });
+  });
+
+  it('ignores non-source children and returns null when nothing is playable', () => {
+    const node = el('video', {}, [text('fallback'), el('track', { src: 't.vtt' })]);
+    expect(extractMediaSource(node)).toBeNull();
+  });
+});
+
+describe('extractPlayerProps', () => {
+  it('returns null without a source', () => {
+    expect(extractPlayerProps(el('video', { controls: '' }), 360)).toBeNull();
+  });
+
+  it('reads value-less boolean attributes (parsed as empty strings)', () => {
+    const props = extractPlayerProps(
+      el('video', { src: 'v.mp4', controls: '', muted: '', loop: '', autoplay: '' }),
+    )!;
+    expect(props.controls).toBe(true);
+    expect(props.muted).toBe(true);
+    expect(props.loop).toBe(true);
+    expect(props.autoplay).toBe(true);
+  });
+
+  it('defaults boolean attributes to false when absent', () => {
+    const props = extractPlayerProps(el('video', { src: 'v.mp4' }))!;
+    expect(props.controls).toBe(false);
+    expect(props.autoplay).toBe(false);
+    expect(props.muted).toBe(false);
+    expect(props.loop).toBe(false);
+  });
+
+  it('computes aspect ratio from width/height attributes', () => {
+    const props = extractPlayerProps(
+      el('video', { src: 'v.mp4', width: '640', height: '360' }),
+    )!;
+    expect(props.aspectRatio).toBeCloseTo(640 / 360);
+  });
+
+  it('falls back to 16/9 for missing or unusable dimensions', () => {
+    for (const attribs of [
+      { src: 'v.mp4' },
+      { src: 'v.mp4', width: '640' },
+      { src: 'v.mp4', width: '640', height: '0' },
+      { src: 'v.mp4', width: 'banana', height: '360' },
+    ]) {
+      expect(extractPlayerProps(el('video', attribs))!.aspectRatio).toBeCloseTo(
+        16 / 9,
+      );
+    }
+  });
+
+  it('caps the width attribute at contentWidth', () => {
+    const node = el('video', { src: 'v.mp4', width: '640' });
+    expect(extractPlayerProps(node, 360)!.width).toBe(360);
+  });
+
+  it('keeps a width attribute smaller than contentWidth', () => {
+    const node = el('video', { src: 'v.mp4', width: '320' });
+    expect(extractPlayerProps(node, 360)!.width).toBe(320);
+  });
+
+  it('uses contentWidth when there is no width attribute', () => {
+    expect(extractPlayerProps(el('video', { src: 'v.mp4' }), 360)!.width).toBe(
+      360,
+    );
+  });
+
+  it('leaves width undefined when neither is known', () => {
+    expect(extractPlayerProps(el('video', { src: 'v.mp4' }))!.width).toBeUndefined();
+  });
+
+  it('passes poster and the original node through', () => {
+    const node = el('video', { src: 'v.mp4', poster: 'p.jpg' });
+    const props = extractPlayerProps(node)!;
+    expect(props.poster).toBe('p.jpg');
+    expect(props.node).toBe(node);
+  });
+});

--- a/packages/video/src/extract.ts
+++ b/packages/video/src/extract.ts
@@ -1,0 +1,77 @@
+import type { RenderElement } from '@nikpnevmatikos/html-renderer';
+import type { MediaSource, VideoPlayerProps } from './types';
+
+const DEFAULT_ASPECT_RATIO = 16 / 9;
+
+/**
+ * Resolve the playable source per HTML semantics: the element's own `src`
+ * attribute wins; otherwise the first `<source>` child that has a `src`.
+ */
+export function extractMediaSource(node: RenderElement): MediaSource | null {
+  const direct = node.attribs?.src;
+  if (direct) return { uri: direct };
+
+  for (const child of node.children) {
+    if (child.kind !== 'element' || child.tag !== 'source') continue;
+    const src = child.attribs?.src;
+    if (!src) continue;
+    const mimeType = child.attribs?.type;
+    return mimeType ? { uri: src, mimeType } : { uri: src };
+  }
+  return null;
+}
+
+function hasBoolAttr(node: RenderElement, name: string): boolean {
+  return node.attribs !== undefined && name in node.attribs;
+}
+
+function positiveNumAttr(
+  node: RenderElement,
+  name: string,
+): number | undefined {
+  const raw = node.attribs?.[name];
+  if (raw === undefined) return undefined;
+  const n = parseFloat(raw);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+/**
+ * Turn a <video> render-tree element into player props, or null when it has
+ * no usable source (the caller should fall back to the element's children —
+ * the HTML fallback content).
+ */
+export function extractPlayerProps(
+  node: RenderElement,
+  contentWidth?: number,
+): VideoPlayerProps | null {
+  const source = extractMediaSource(node);
+  if (source === null) return null;
+
+  const attrWidth = positiveNumAttr(node, 'width');
+  const attrHeight = positiveNumAttr(node, 'height');
+  const aspectRatio =
+    attrWidth !== undefined && attrHeight !== undefined
+      ? attrWidth / attrHeight
+      : DEFAULT_ASPECT_RATIO;
+
+  let width: number | undefined;
+  if (attrWidth !== undefined && contentWidth !== undefined) {
+    width = Math.min(attrWidth, contentWidth);
+  } else {
+    width = attrWidth ?? contentWidth;
+  }
+
+  const props: VideoPlayerProps = {
+    source,
+    controls: hasBoolAttr(node, 'controls'),
+    autoplay: hasBoolAttr(node, 'autoplay'),
+    muted: hasBoolAttr(node, 'muted'),
+    loop: hasBoolAttr(node, 'loop'),
+    aspectRatio,
+    node,
+  };
+  const poster = node.attribs?.poster;
+  if (poster) props.poster = poster;
+  if (width !== undefined) props.width = width;
+  return props;
+}

--- a/packages/video/src/fixtures.test-util.ts
+++ b/packages/video/src/fixtures.test-util.ts
@@ -1,0 +1,17 @@
+import type { RenderElement, RenderNode } from '@nikpnevmatikos/html-renderer';
+
+// Hand-built render-tree fixtures, typed against the core package so any
+// structural drift fails typecheck. The parse→attribs shape itself (value-less
+// boolean attrs as '', <source> children, etc.) is pinned by core's own
+// build.test.ts; core's dist is ESM and can't be require()d by node jest.
+export function el(
+  tag: string,
+  attribs: Record<string, string> = {},
+  children: RenderNode[] = [],
+): RenderElement {
+  return { kind: 'element', tag, display: 'block', style: {}, attribs, children };
+}
+
+export function text(t: string): RenderNode {
+  return { kind: 'text', text: t, style: {} };
+}

--- a/packages/video/src/index.test.ts
+++ b/packages/video/src/index.test.ts
@@ -1,0 +1,11 @@
+import { createVideoRenderers } from './index';
+
+// Scaffold smoke test — replaced by real coverage when the factory lands.
+describe('createVideoRenderers (scaffold)', () => {
+  it('exports the factory and reports unimplemented for now', () => {
+    expect(typeof createVideoRenderers).toBe('function');
+    expect(() => createVideoRenderers((() => null) as never)).toThrow(
+      /not implemented/i,
+    );
+  });
+});

--- a/packages/video/src/index.test.ts
+++ b/packages/video/src/index.test.ts
@@ -1,11 +1,57 @@
-import { createVideoRenderers } from './index';
+import type { ComponentType, ReactElement } from 'react';
+import type { RenderElement } from '@nikpnevmatikos/html-renderer';
+import { createVideoRenderers, type VideoPlayerProps } from './index';
+import { el, text } from './fixtures.test-util';
 
-// Scaffold smoke test — replaced by real coverage when the factory lands.
-describe('createVideoRenderers (scaffold)', () => {
-  it('exports the factory and reports unimplemented for now', () => {
-    expect(typeof createVideoRenderers).toBe('function');
-    expect(() => createVideoRenderers((() => null) as never)).toThrow(
-      /not implemented/i,
-    );
+const Player: ComponentType<VideoPlayerProps> = () => null;
+
+function render(node: RenderElement, contentWidth?: number) {
+  const cfg = createVideoRenderers(Player);
+  const renderer = cfg.customRenderers.video!;
+  return renderer(node, () => 'FALLBACK', {
+    renderersProps: {},
+    ...(contentWidth !== undefined ? { contentWidth } : {}),
+  });
+}
+
+describe('createVideoRenderers', () => {
+  it('declares video as a block element model', () => {
+    const cfg = createVideoRenderers(Player);
+    expect(cfg.customHTMLElementModels.video).toEqual({ display: 'block' });
+  });
+
+  it('renders the player element with extracted props', () => {
+    const node = el('video', {
+      src: 'v.mp4',
+      poster: 'p.jpg',
+      controls: '',
+      width: '640',
+      height: '360',
+    });
+    const rendered = render(node, 360) as ReactElement<VideoPlayerProps>;
+    expect(rendered.type).toBe(Player);
+    expect(rendered.props.source).toEqual({ uri: 'v.mp4' });
+    expect(rendered.props.poster).toBe('p.jpg');
+    expect(rendered.props.controls).toBe(true);
+    expect(rendered.props.width).toBe(360);
+    expect(rendered.props.aspectRatio).toBeCloseTo(640 / 360);
+    expect(rendered.props.node).toBe(node);
+  });
+
+  it('resolves <source> children', () => {
+    const node = el('video', {}, [
+      el('source', { src: 'v.webm', type: 'video/webm' }),
+      text('fallback'),
+    ]);
+    const rendered = render(node) as ReactElement<VideoPlayerProps>;
+    expect(rendered.type).toBe(Player);
+    expect(rendered.props.source).toEqual({
+      uri: 'v.webm',
+      mimeType: 'video/webm',
+    });
+  });
+
+  it('falls back to defaultRender when no source is playable', () => {
+    expect(render(el('video', {}, [text('no video support')]))).toBe('FALLBACK');
   });
 });

--- a/packages/video/src/index.ts
+++ b/packages/video/src/index.ts
@@ -1,0 +1,55 @@
+import type {
+  CustomRenderer,
+  HTMLElementModel,
+  RenderElement,
+} from '@nikpnevmatikos/html-renderer';
+import type { ComponentType } from 'react';
+
+/** A playable source resolved from a media element. */
+export interface MediaSource {
+  uri: string;
+  /** MIME type from the src-bearing element, when present (e.g. "video/mp4"). */
+  mimeType?: string;
+}
+
+/** Props every player adapter receives from the video renderer. */
+export interface VideoPlayerProps {
+  source: MediaSource;
+  poster?: string;
+  controls: boolean;
+  autoplay: boolean;
+  muted: boolean;
+  loop: boolean;
+  /** Pixel width to occupy: min(width attribute, contentWidth) when known. */
+  width?: number;
+  /** Ratio of the width/height attributes; defaults to 16/9. */
+  aspectRatio: number;
+  /** The underlying render-tree element, for advanced adapters. */
+  node: RenderElement;
+}
+
+/** Ready-to-spread HtmlRenderer props wiring <video> to a player component. */
+export interface VideoRenderersConfig {
+  customRenderers: Record<string, CustomRenderer>;
+  customHTMLElementModels: Record<string, HTMLElementModel>;
+}
+
+/**
+ * Build the customRenderers / customHTMLElementModels pair that wires <video>
+ * to the given player component:
+ *
+ *   const video = createVideoRenderers(MyPlayer);
+ *   <HtmlRenderer html={html} {...video} />
+ *
+ * Player must be a real component — the renderer returns <Player /> elements,
+ * so hooks are legal inside it. Elements with no usable source fall back to
+ * their HTML fallback content.
+ */
+export function createVideoRenderers(
+  _Player: ComponentType<VideoPlayerProps>,
+): VideoRenderersConfig {
+  throw new Error(
+    '@nikpnevmatikos/html-renderer-video is under development: ' +
+      'createVideoRenderers is not implemented yet.',
+  );
+}

--- a/packages/video/src/index.ts
+++ b/packages/video/src/index.ts
@@ -1,38 +1,14 @@
-import type {
-  CustomRenderer,
-  HTMLElementModel,
-  RenderElement,
-} from '@nikpnevmatikos/html-renderer';
-import type { ComponentType } from 'react';
+import { createElement, type ComponentType } from 'react';
+import type { CustomRenderer } from '@nikpnevmatikos/html-renderer';
+import type { VideoPlayerProps, VideoRenderersConfig } from './types';
+import { extractPlayerProps } from './extract';
 
-/** A playable source resolved from a media element. */
-export interface MediaSource {
-  uri: string;
-  /** MIME type from the src-bearing element, when present (e.g. "video/mp4"). */
-  mimeType?: string;
-}
-
-/** Props every player adapter receives from the video renderer. */
-export interface VideoPlayerProps {
-  source: MediaSource;
-  poster?: string;
-  controls: boolean;
-  autoplay: boolean;
-  muted: boolean;
-  loop: boolean;
-  /** Pixel width to occupy: min(width attribute, contentWidth) when known. */
-  width?: number;
-  /** Ratio of the width/height attributes; defaults to 16/9. */
-  aspectRatio: number;
-  /** The underlying render-tree element, for advanced adapters. */
-  node: RenderElement;
-}
-
-/** Ready-to-spread HtmlRenderer props wiring <video> to a player component. */
-export interface VideoRenderersConfig {
-  customRenderers: Record<string, CustomRenderer>;
-  customHTMLElementModels: Record<string, HTMLElementModel>;
-}
+export type {
+  MediaSource,
+  VideoPlayerProps,
+  VideoRenderersConfig,
+} from './types';
+export { extractMediaSource, extractPlayerProps } from './extract';
 
 /**
  * Build the customRenderers / customHTMLElementModels pair that wires <video>
@@ -46,10 +22,18 @@ export interface VideoRenderersConfig {
  * their HTML fallback content.
  */
 export function createVideoRenderers(
-  _Player: ComponentType<VideoPlayerProps>,
+  Player: ComponentType<VideoPlayerProps>,
 ): VideoRenderersConfig {
-  throw new Error(
-    '@nikpnevmatikos/html-renderer-video is under development: ' +
-      'createVideoRenderers is not implemented yet.',
-  );
+  const video: CustomRenderer = (node, defaultRender, info) => {
+    const props = extractPlayerProps(node, info.contentWidth);
+    if (props === null) return defaultRender();
+    return createElement(Player, props);
+  };
+
+  return {
+    customRenderers: { video },
+    customHTMLElementModels: {
+      video: { display: 'block' },
+    },
+  };
 }

--- a/packages/video/src/types.ts
+++ b/packages/video/src/types.ts
@@ -1,0 +1,34 @@
+import type {
+  CustomRenderer,
+  HTMLElementModel,
+  RenderElement,
+} from '@nikpnevmatikos/html-renderer';
+
+/** A playable source resolved from a media element. */
+export interface MediaSource {
+  uri: string;
+  /** MIME type from the src-bearing element, when present (e.g. "video/mp4"). */
+  mimeType?: string;
+}
+
+/** Props every player adapter receives from the video renderer. */
+export interface VideoPlayerProps {
+  source: MediaSource;
+  poster?: string;
+  controls: boolean;
+  autoplay: boolean;
+  muted: boolean;
+  loop: boolean;
+  /** Pixel width to occupy: min(width attribute, contentWidth) when known. */
+  width?: number;
+  /** Ratio of the width/height attributes; defaults to 16/9. */
+  aspectRatio: number;
+  /** The underlying render-tree element, for advanced adapters. */
+  node: RenderElement;
+}
+
+/** Ready-to-spread HtmlRenderer props wiring <video> to a player component. */
+export interface VideoRenderersConfig {
+  customRenderers: Record<string, CustomRenderer>;
+  customHTMLElementModels: Record<string, HTMLElementModel>;
+}

--- a/packages/video/tsconfig.json
+++ b/packages/video/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["dist", "**/*.test.ts", "**/*.test.tsx", "**/*.test-util.ts"]
 }

--- a/packages/video/tsconfig.json
+++ b/packages/video/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "**/*.test.ts", "**/*.test.tsx"]
+}


### PR DESCRIPTION
## Summary

New workspace package **`@nikpnevmatikos/html-renderer-video@0.1.0`** — `<video>` support for the HTML renderer.

- **Player-agnostic core**: `createVideoRenderers(Player)` returns the `customRenderers`/`customHTMLElementModels` pair for any player component (`VideoPlayerProps` contract).
- **HTML semantics**: `src` attribute or first usable `<source>` child (MIME type carried through); fallback content renders when nothing is playable; width capped at `contentWidth`; aspect ratio from `width`/`height` (16/9 default); boolean `controls`/`autoplay`/`muted`/`loop`.
- **`/expo` subpath adapter** (`createExpoVideoRenderers`) wired to `expo-video` (optional peer): poster overlay with tap-to-play badge (posters are otherwise indistinguishable from images, and controls-less videos would be unstartable), loading/buffering spinners driven by player status, autoplay re-request post-mount (web drops `play()` from the setup callback). Physical `expo.js`/`expo.d.ts` stubs for exports-unaware resolvers.
- **Example app**: video demo section; root README plugin table updated; root scripts/CI now build+test all workspaces (build-first ordering).

## Test plan

- 19 unit tests on extraction/factory (154 total across workspaces), typecheck (incl. example app), builds.
- Verified live on expo web through the real package boundary (metro + exports map): source resolution, poster/badge behavior, tap-to-play, fallback content, autoplay muted+loop, rebuffer spinner on deep seek, sizing at contentWidth.
- Not exercised on physical iOS/Android devices — worth a quick Expo Go pass after merge.